### PR TITLE
Fix day slots when they cross DST bounds

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -394,7 +394,7 @@ test("Bounds and day slot aren't the same timezone, so days of the week differ",
 
 test("Day slot across Daylight savings time", () => {
   const { allSlots } = getSlots({
-    from: DateTime.fromObject({ year: 2024, month: 3, day: 10, hour: 4 }, { zone: "America/Los_Angeles" }).toISO(),
+    from: DateTime.fromObject({ year: 2024, month: 3, day: 10, hour: 1 }, { zone: "America/Los_Angeles" }).toISO(),
     to: DateTime.fromObject({ year: 2024, month: 3, day: 10, hour: 7 }, { zone: "America/Los_Angeles" }).toISO(),
     availability: [
       {
@@ -407,7 +407,26 @@ test("Day slot across Daylight savings time", () => {
     duration: 60,
   });
 
+  console.log(allSlots);
+
+  console.log("START", DateTime.fromISO("2024-03-10T01:00:00.000-07:00").toUTC().toISO());
+  console.log("SHOULD", DateTime.fromISO("2024-03-10T05:00:00.000-07:00").toUTC().toISO());
+
   expect(allSlots).toEqual([
+    // PST is -8
+    {
+      from: DateTime.fromISO("2024-03-10T01:00:00.000-08:00").toUTC().toISO(),
+      to: DateTime.fromISO("2024-03-10T02:00:00.000-08:00").toUTC().toISO(),
+      available: false,
+    },
+    // The 2-3 slot doesn't exist
+
+    // PDT is -7
+    {
+      from: DateTime.fromISO("2024-03-10T03:00:00.000-07:00").toUTC().toISO(),
+      to: DateTime.fromISO("2024-03-10T04:00:00.000-07:00").toUTC().toISO(),
+      available: false,
+    },
     {
       from: DateTime.fromISO("2024-03-10T04:00:00.000-07:00").toUTC().toISO(),
       to: DateTime.fromISO("2024-03-10T05:00:00.000-07:00").toUTC().toISO(),

--- a/index.test.ts
+++ b/index.test.ts
@@ -407,11 +407,6 @@ test("Day slot across Daylight savings time", () => {
     duration: 60,
   });
 
-  console.log(allSlots);
-
-  console.log("START", DateTime.fromISO("2024-03-10T01:00:00.000-07:00").toUTC().toISO());
-  console.log("SHOULD", DateTime.fromISO("2024-03-10T05:00:00.000-07:00").toUTC().toISO());
-
   expect(allSlots).toEqual([
     // PST is -8
     {

--- a/index.test.ts
+++ b/index.test.ts
@@ -392,6 +392,40 @@ test("Bounds and day slot aren't the same timezone, so days of the week differ",
   ]);
 });
 
+test("Day slot across Daylight savings time", () => {
+  const { allSlots } = getSlots({
+    from: DateTime.fromObject({ year: 2024, month: 3, day: 10, hour: 4 }, { zone: "America/Los_Angeles" }).toISO(),
+    to: DateTime.fromObject({ year: 2024, month: 3, day: 10, hour: 7 }, { zone: "America/Los_Angeles" }).toISO(),
+    availability: [
+      {
+        day: "Sunday",
+        from: "05:00",
+        to: "06:00",
+        timezone: "America/Los_Angeles",
+      },
+    ],
+    duration: 60,
+  });
+
+  expect(allSlots).toEqual([
+    {
+      from: DateTime.fromISO("2024-03-10T04:00:00.000-07:00").toUTC().toISO(),
+      to: DateTime.fromISO("2024-03-10T05:00:00.000-07:00").toUTC().toISO(),
+      available: false,
+    },
+    {
+      from: DateTime.fromISO("2024-03-10T05:00:00.000-07:00").toUTC().toISO(),
+      to: DateTime.fromISO("2024-03-10T06:00:00.000-07:00").toUTC().toISO(),
+      available: true,
+    },
+    {
+      from: DateTime.fromISO("2024-03-10T06:00:00.000-07:00").toUTC().toISO(),
+      to: DateTime.fromISO("2024-03-10T07:00:00.000-07:00").toUTC().toISO(),
+      available: false,
+    },
+  ]);
+});
+
 test("Helper variables", async () => {
   // false, true
   const {

--- a/index.ts
+++ b/index.ts
@@ -219,17 +219,17 @@ export function getSlots(config: {
             from: DateTime.fromISO(date, {
               zone: slot.timezone,
             })
-              .plus({
-                hours: Number(slot.from.split(":")[0]),
-                minutes: Number(slot.from.split(":")[1]),
+              .set({
+                hour: Number(slot.from.split(":")[0]),
+                minute: Number(slot.from.split(":")[1]),
               })
               .toISO(),
             to: DateTime.fromISO(date, {
               zone: slot.timezone,
             })
-              .plus({
-                hours: Number(slot.to.split(":")[0]),
-                minutes: Number(slot.to.split(":")[1]),
+              .set({
+                hour: Number(slot.to.split(":")[0]),
+                minute: Number(slot.to.split(":")[1]),
               })
               .toISO(),
             metadata: slot.metadata,


### PR DESCRIPTION
Currently when day slots cross DST bounds they end up being pulled back (or forwards) since there is an extra (or 1 less) hour in the day.

Including an illustrative test.